### PR TITLE
Update constructionList.py

### DIFF
--- a/ikabot/function/constructionList.py
+++ b/ikabot/function/constructionList.py
@@ -284,7 +284,9 @@ def getResourcesNeeded(session, city, building, current_level, final_level):
 
         levels_to_upgrade += 1
         # get the costs for the current level
-        costs = re.findall(r'<td class="costs"><div.*>([\d,\.]*)</div></div></td>', match)
+        costs = re.findall(r'<td class="costs"><div.*>([\d,\.\s\xa0]*)</div></div></td>', match)
+        # delete blank spaces (\xa0) in costs
+        costs = [value.replace('\xa0', '').replace(' ', '') for value in costs]
 
         for i in range(len(costs)):
             # get hash from CDN images to identify the resource type


### PR DESCRIPTION
With this update ikabot is able to correctly get all the values in the construction list, including values that include blank spaces.

Account for testing with ES lang

The update allow to get all the values when there are blank spaces in the quantities.

**Account Lang**: es_ES

Output before the change
`current level:1
increase to level:38
['174']

['279']

['410']

['577']

['786', '669']

['905']

[]

[]

[]

[]

[]

[]

[]

[]

[]

[]

[]

[]

[]

[]

[]

[]

[]

[]

[]

[]

[]

[]

[]

[]

[]

[]

[]

[]

[]

[]

[]


Materials needed:
- Wood: 1.970
- Marble: 421


You have enough materials
Proceed? [Y/n]
 >>`

Output after the change
`current level:1
increase to level:38
['174']

['279']

['410']

['577']

['786', '669']

['1051', '905']

['1384', '1201']

['1803', '1576']

['2331', '2048']

['2997', '2641']

['3836', '3390']

['4893', '4333']

['6225', '5521']

['7903', '7018']

['10017', '8904']

['12682', '11281']

['16039', '14277']

['20268', '18051']

['25598', '22805']

['32313', '28796']

['40774', '36344']

['51435', '45856']

['64868', '57840']

['81793', '72940']

['103119', '91967']

['129990', '115940']

['163847', '146146']

['206507', '184205']

['260258', '232160']

['327985', '292584']

['413320', '368717']

['520844', '464646']

['656323', '585516']

['827027', '737811']

['1042113', '929704']

['1313122', '1171489']

['1654594', '1476137']


Materials needed:
- Wood: 5.029.233
- Marble: 4.485.418


Missing:
3.685.858 of wood
3.386.565 of marble`